### PR TITLE
Fix the issue where MultiChannel acquisition is flipped relative to the Live View

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -9,11 +9,16 @@ def conf_attribute_reader(string_value):
     """
     :brief: standardized way for reading config entries
     that are strings, in priority order
-    dict/list (via json) -> int -> float -> string
+    None -> bool -> dict/list (via json) -> int -> float -> string
     REMEMBER TO ENCLOSE PROPERTY NAMES IN LISTS/DICTS IN
     DOUBLE QUOTES
     """
     actualvalue = str(string_value).strip()
+    try:
+        if str(actualvalue) == "None":
+            return None
+    except:
+        pass
     try:
         if str(actualvalue) == "True" or str(actualvalue) == "true":
             return True

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -1051,6 +1051,7 @@ class AutofocusWorker(QObject):
             if self.liveController.trigger_mode == TriggerMode.SOFTWARE:
                 self.liveController.turn_off_illumination()
             image = utils.crop_image(image,self.crop_width,self.crop_height)
+            image = utils.rotate_and_flip_image(image,rotate_image_angle=self.camera.rotate_image_angle,flip_image=self.camera.flip_image)
             self.image_to_display.emit(image)
             QApplication.processEvents()
             timestamp_0 = time.time()
@@ -1493,7 +1494,9 @@ class MultiPointWorker(QObject):
                                     image = utils.rotate_and_flip_image(image,rotate_image_angle=self.camera.rotate_image_angle,flip_image=self.camera.flip_image)
                                     # self.image_to_display.emit(cv2.resize(image,(round(self.crop_width*self.display_resolution_scaling), round(self.crop_height*self.display_resolution_scaling)),cv2.INTER_LINEAR))
                                     image_to_display = utils.crop_image(image,round(self.crop_width*self.display_resolution_scaling), round(self.crop_height*self.display_resolution_scaling))
+                                    print("emitting image to display")
                                     self.image_to_display.emit(image_to_display)
+                                    print("emitting image to display multi")
                                     self.image_to_display_multi.emit(image_to_display,config.illumination_source)
                                     stitcher_tile_path = None
                                     stitcher_of_interest = None
@@ -2330,7 +2333,7 @@ class ImageDisplayWindow(QMainWindow):
 
         self.graphics_widget = pg.GraphicsLayoutWidget()
         self.graphics_widget.view = self.graphics_widget.addViewBox()
-        self.graphics_widget.view.invertY()
+        #self.graphics_widget.view.invertY()
         
         ## lock the aspect ratio so pixels are always square
         self.graphics_widget.view.setAspectLocked(True)

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -1494,9 +1494,7 @@ class MultiPointWorker(QObject):
                                     image = utils.rotate_and_flip_image(image,rotate_image_angle=self.camera.rotate_image_angle,flip_image=self.camera.flip_image)
                                     # self.image_to_display.emit(cv2.resize(image,(round(self.crop_width*self.display_resolution_scaling), round(self.crop_height*self.display_resolution_scaling)),cv2.INTER_LINEAR))
                                     image_to_display = utils.crop_image(image,round(self.crop_width*self.display_resolution_scaling), round(self.crop_height*self.display_resolution_scaling))
-                                    print("emitting image to display")
                                     self.image_to_display.emit(image_to_display)
-                                    print("emitting image to display multi")
                                     self.image_to_display_multi.emit(image_to_display,config.illumination_source)
                                     stitcher_tile_path = None
                                     stitcher_of_interest = None

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -2333,7 +2333,7 @@ class ImageDisplayWindow(QMainWindow):
 
         self.graphics_widget = pg.GraphicsLayoutWidget()
         self.graphics_widget.view = self.graphics_widget.addViewBox()
-        #self.graphics_widget.view.invertY()
+        self.graphics_widget.view.invertY()
         
         ## lock the aspect ratio so pixels are always square
         self.graphics_widget.view.setAspectLocked(True)
@@ -2588,26 +2588,29 @@ class ImageArrayDisplayWindow(QMainWindow):
         self.graphics_widget_1.view = self.graphics_widget_1.addViewBox()
         self.graphics_widget_1.view.setAspectLocked(True)
         self.graphics_widget_1.img = pg.ImageItem(border='w')
-        self.graphics_widget_1.view.addItem(self.graphics_widget_1.img)
+        self.graphics_widget_1.view.addItem(self.graphics_widget_1.img) 
+        self.graphics_widget_1.view.invertY()
 
         self.graphics_widget_2 = pg.GraphicsLayoutWidget()
         self.graphics_widget_2.view = self.graphics_widget_2.addViewBox()
         self.graphics_widget_2.view.setAspectLocked(True)
         self.graphics_widget_2.img = pg.ImageItem(border='w')
         self.graphics_widget_2.view.addItem(self.graphics_widget_2.img)
+        self.graphics_widget_2.view.invertY()
 
         self.graphics_widget_3 = pg.GraphicsLayoutWidget()
         self.graphics_widget_3.view = self.graphics_widget_3.addViewBox()
         self.graphics_widget_3.view.setAspectLocked(True)
         self.graphics_widget_3.img = pg.ImageItem(border='w')
         self.graphics_widget_3.view.addItem(self.graphics_widget_3.img)
+        self.graphics_widget_3.view.invertY()
 
         self.graphics_widget_4 = pg.GraphicsLayoutWidget()
         self.graphics_widget_4.view = self.graphics_widget_4.addViewBox()
         self.graphics_widget_4.view.setAspectLocked(True)
         self.graphics_widget_4.img = pg.ImageItem(border='w')
         self.graphics_widget_4.view.addItem(self.graphics_widget_4.img)
-
+        self.graphics_widget_4.view.invertY()
         ## Layout
         layout = QGridLayout()
         layout.addWidget(self.graphics_widget_1, 0, 0)

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -36,17 +36,18 @@ def unsigned_to_signed(unsigned_array,N):
     return signed
 
 def rotate_and_flip_image(image,rotate_image_angle,flip_image):
+    ret_image = image.copy()
     if(rotate_image_angle != 0):
         '''
             # ROTATE_90_CLOCKWISE
             # ROTATE_90_COUNTERCLOCKWISE
         '''
         if(rotate_image_angle == 90):
-            image = cv2.rotate(image,cv2.ROTATE_90_CLOCKWISE)
+            ret_image = cv2.rotate(ret_image,cv2.ROTATE_90_CLOCKWISE)
         elif(rotate_image_angle == -90):
-            image = cv2.rotate(image,cv2.ROTATE_90_COUNTERCLOCKWISE)
+            ret_image = cv2.rotate(ret_image,cv2.ROTATE_90_COUNTERCLOCKWISE)
         elif(rotate_image_angle == 180):
-            image = cv2.rotate(image,cv2.ROTATE_180)
+            ret_image = cv2.rotate(ret_image,cv2.ROTATE_180)
 
     if(flip_image is not None):
         '''
@@ -55,13 +56,14 @@ def rotate_and_flip_image(image,rotate_image_angle,flip_image):
             flipcode < 0: flip vertically and horizontally
         '''
         if(flip_image == 'Vertical'):
-            image = cv2.flip(image, 0)
+            ret_image = cv2.flip(ret_image, 0)
         elif(flip_image == 'Horizontal'):
-            image = cv2.flip(image, 1)
+            ret_image = cv2.flip(ret_image, 1)
         elif(flip_image == 'Both'):
-            image = cv2.flip(image, -1)
+            ret_image = cv2.flip(ret_image, -1)
 
-    return image
+    print("rotated and flipped image")
+    return ret_image
 
 def generate_dpc(im_left, im_right):
     # Normalize the images

--- a/software/control/utils.py
+++ b/software/control/utils.py
@@ -62,7 +62,6 @@ def rotate_and_flip_image(image,rotate_image_angle,flip_image):
         elif(flip_image == 'Both'):
             ret_image = cv2.flip(ret_image, -1)
 
-    print("rotated and flipped image")
     return ret_image
 
 def generate_dpc(im_left, im_right):


### PR DESCRIPTION
* Add the invertY option present in the ImageDisplayWindow's graphics widget to the ImageArrayDisplayWindow for view consistency
* Add a crop-and-rotate step to the contrast AF worker's workflow: Since contrast AF causes the Live View to display whatever the autofocus worker sends out, the AF worker should also rotate and flip its image to avoid a discontinuity in the stream to the Live View window
* Made rotate_and_flip_image under utils.py non-destructive: The function no longer modifies ndarrays in place, and instead makes a copy on which it performs the modifications before returning
* Added "None"-parsing to the config reader function in control/_def: Non-critical, parses an entry as python `None` if its text is "None"