### PR TITLE
Adding state-caching for laser autofocus

### DIFF
--- a/software/.gitignore
+++ b/software/.gitignore
@@ -1,3 +1,4 @@
 *.ini
 *.txt
 *_configurations.xml
+cache/

--- a/software/configurations/configuration_HCS_v2.ini
+++ b/software/configurations/configuration_HCS_v2.ini
@@ -109,7 +109,7 @@ focus_measure_operator=GLVA
 controller_version=Teensy
 support_laser_autofocus=True
 _support_laser_autofocus_options=[True,False]
-main_camera_model=MER-1220-32U3M
+main_camera_model=MER2-1220-32U3M
 focus_camera_model=MER2-630-60U3M
 focus_camera_exposure_time_ms=0.8
 
@@ -118,6 +118,9 @@ _has_two_interfaces_options=[True,False]
 
 enable_flexible_multipoint=True
 _enable_flexible_multipoint_options=[True,False]
+
+default_multipoint_nx=1
+default_multipoint_ny=1
 
 [LIMIT_SWITCH_POLARITY]
 x_home = 1

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -358,6 +358,9 @@ MULTIPOINT_BF_SAVING_OPTION = 'Raw'
 # MULTIPOINT_BF_SAVING_OPTION = 'RGB2GRAY'
 # MULTIPOINT_BF_SAVING_OPTION = 'Green Channel Only'
 
+DEFAULT_MULTIPOINT_NX=1
+DEFAULT_MULTIPOINT_NY=1
+
 ENABLE_FLEXIBLE_MULTIPOINT = False
 
 CAMERA_SN = {'ch 1':'SN1','ch 2': 'SN2'} # for multiple cameras, to be overwritten in the configuration file

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -2840,7 +2840,7 @@ class LaserAutofocusController(QObject):
     image_to_display = Signal(np.ndarray)
     signal_displacement_um = Signal(float)
 
-    def __init__(self,microcontroller,camera,liveController,navigationController,has_two_interfaces=True,use_glass_top=True, look_for_cache=False):
+    def __init__(self,microcontroller,camera,liveController,navigationController,has_two_interfaces=True,use_glass_top=True, look_for_cache=True):
         QObject.__init__(self)
         self.microcontroller = microcontroller
         self.camera = camera
@@ -2865,16 +2865,17 @@ class LaserAutofocusController(QObject):
                 with open(cache_path, "r") as cache_file:
                     for line in cache_file:
                         value_list = line.split(",")
-                        x_offset = int(value_list[0])
-                        y_offset = int(value_list[1])
+                        x_offset = float(value_list[0])
+                        y_offset = float(value_list[1])
                         width = int(value_list[2])
                         height = int(value_list[3])
                         pixel_to_um = float(value_list[4])
                         x_reference = float(value_list[5])
                         self.initialize_manual(x_offset,y_offset,width,height,pixel_to_um,x_reference)
                         break
-            except (FileNotFoundError, ValueError,IndexError):
-                print("Error reading Laser AF state cache")
+            except (FileNotFoundError, ValueError,IndexError) as e:
+                print("Unable to read laser AF state cache, exception below:")
+                print(e)
                 pass
 
     def initialize_manual(self, x_offset, y_offset, width, height, pixel_to_um, x_reference, write_to_cache=True):
@@ -2889,7 +2890,7 @@ class LaserAutofocusController(QObject):
         cache_string = ",".join([str(x_offset),str(y_offset), str(width),str(height), str(pixel_to_um), str(x_reference)])
         if write_to_cache:
             cache_path = Path("cache/laser_af_reference_plane.txt")
-            file.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
             cache_path.write_text(cache_string)
         self.is_initialized = True
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -361,6 +361,7 @@ class CameraSettingsWidget(QFrame):
         if self.camera.pixel_format is not None:
             self.dropdown_pixelFormat.setCurrentText(self.camera.pixel_format)
         else:
+            print("setting camera's default pixel format")
             self.camera.set_pixel_format(DEFAULT_PIXEL_FORMAT)
             self.dropdown_pixelFormat.setCurrentText(DEFAULT_PIXEL_FORMAT)
         # to do: load and save pixel format in configurations
@@ -1223,7 +1224,7 @@ class MultiPointWidget(QFrame):
         self.entry_NX.setMinimum(1) 
         self.entry_NX.setMaximum(50) 
         self.entry_NX.setSingleStep(1)
-        self.entry_NX.setValue(6)
+        self.entry_NX.setValue(DEFAULT_MULTIPOINT_NX)
         self.entry_NX.setKeyboardTracking(False)
 
         self.entry_deltaY = QDoubleSpinBox()
@@ -1238,7 +1239,7 @@ class MultiPointWidget(QFrame):
         self.entry_NY.setMinimum(1) 
         self.entry_NY.setMaximum(50) 
         self.entry_NY.setSingleStep(1)
-        self.entry_NY.setValue(3)
+        self.entry_NY.setValue(DEFAULT_MULTIPOINT_NY)
         self.entry_NY.setKeyboardTracking(False)
 
         self.entry_deltaZ = QDoubleSpinBox()

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2662,7 +2662,8 @@ class LaserAutofocusControlWidget(QFrame):
         self.btn_set_reference.setCheckable(False)
         self.btn_set_reference.setChecked(False)
         self.btn_set_reference.setDefault(False)
-        self.btn_set_reference.setEnabled(False)
+        if not self.laserAutofocusController.is_initialized:
+            self.btn_set_reference.setEnabled(False)
 
         self.label_displacement = QLabel()
         self.label_displacement.setFrameStyle(QFrame.Panel | QFrame.Sunken)
@@ -2671,7 +2672,8 @@ class LaserAutofocusControlWidget(QFrame):
         self.btn_measure_displacement.setCheckable(False)
         self.btn_measure_displacement.setChecked(False)
         self.btn_measure_displacement.setDefault(False)
-        self.btn_measure_displacement.setEnabled(False)
+        if not self.laserAutofocusController.is_initialized:
+            self.btn_measure_displacement.setEnabled(False)
 
         self.entry_target = QDoubleSpinBox()
         self.entry_target.setMinimum(-100)
@@ -2685,8 +2687,9 @@ class LaserAutofocusControlWidget(QFrame):
         self.btn_move_to_target.setCheckable(False)
         self.btn_move_to_target.setChecked(False)
         self.btn_move_to_target.setDefault(False)
-        self.btn_move_to_target.setEnabled(False)
-
+        if not self.laserAutofocusController.is_initialized:
+            self.btn_move_to_target.setEnabled(False)
+        
         self.grid = QGridLayout()
         self.grid.addWidget(self.btn_initialize,0,0,1,3)
         self.grid.addWidget(self.btn_set_reference,1,0,1,3)


### PR DESCRIPTION
Creates a text file under a directory called `cache` that stores the arguments last used to call `initialize_manual` for the laser AF controller, and reinitializes from this when the program is reopened.