### PR TITLE
Editable points table

### DIFF
--- a/software/control/core.py
+++ b/software/control/core.py
@@ -3289,6 +3289,8 @@ class ScanCoordinates(object):
         # clear the previous selection
         self.coordinates_mm = []
         self.name = []
+        if len(selected_wells) == 0:
+            return
         # populate the coordinates
         rows = np.unique(selected_wells[:,0])
         _increasing = True

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -272,7 +272,10 @@ class OctopiGUI(QMainWindow):
         if ENABLE_TRACKING:
             self.trackingControlWidget = widgets.TrackingControllerWidget(self.trackingController,self.configurationManager,show_configurations=TRACKING_SHOW_MICROSCOPE_CONFIGURATIONS)
         self.multiPointWidget = widgets.MultiPointWidget(self.multipointController,self.configurationManager)
-
+        self.wellSelectionWidget = widgets.WellSelectionWidget(WELLPLATE_FORMAT)
+        self.scanCoordinates.add_well_selector(self.wellSelectionWidget)
+        self.multiPointWidget2 = widgets.MultiPointWidget2(self.navigationController,self.navigationViewer,self.multipointController,self.configurationManager,scanCoordinates=self.scanCoordinates)
+        
         self.recordTabWidget = QTabWidget()
         if ENABLE_TRACKING:
             self.recordTabWidget.addTab(self.trackingControlWidget, "Tracking")
@@ -282,10 +285,6 @@ class OctopiGUI(QMainWindow):
         if ENABLE_SPINNING_DISK_CONFOCAL:
             self.recordTabWidget.addTab(self.spinningDiskConfocalWidget,"Spinning Disk Confocal")
         self.recordTabWidget.addTab(self.recordingControlWidget, "Simple Recording")
-
-        self.wellSelectionWidget = widgets.WellSelectionWidget(WELLPLATE_FORMAT)
-        self.scanCoordinates.add_well_selector(self.wellSelectionWidget)
-        self.multiPointWidget2 = widgets.MultiPointWidget2(self.navigationController,self.navigationViewer,self.multipointController,self.configurationManager,scanCoordinates=self.scanCoordinates)
 
         # layout widgets
         layout = QVBoxLayout() #layout = QStackedLayout()

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -272,7 +272,6 @@ class OctopiGUI(QMainWindow):
         if ENABLE_TRACKING:
             self.trackingControlWidget = widgets.TrackingControllerWidget(self.trackingController,self.configurationManager,show_configurations=TRACKING_SHOW_MICROSCOPE_CONFIGURATIONS)
         self.multiPointWidget = widgets.MultiPointWidget(self.multipointController,self.configurationManager)
-        self.multiPointWidget2 = widgets.MultiPointWidget2(self.navigationController,self.navigationViewer,self.multipointController,self.configurationManager)
 
         self.recordTabWidget = QTabWidget()
         if ENABLE_TRACKING:
@@ -286,6 +285,7 @@ class OctopiGUI(QMainWindow):
 
         self.wellSelectionWidget = widgets.WellSelectionWidget(WELLPLATE_FORMAT)
         self.scanCoordinates.add_well_selector(self.wellSelectionWidget)
+        self.multiPointWidget2 = widgets.MultiPointWidget2(self.navigationController,self.navigationViewer,self.multipointController,self.configurationManager,scanCoordinates=self.scanCoordinates)
 
         # layout widgets
         layout = QVBoxLayout() #layout = QStackedLayout()

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2214,16 +2214,21 @@ class MultiPointWidget2(QFrame):
         self.dropdown_location_list.setCurrentIndex(row)
 
     def cell_was_changed(self,row,column):
-        x = self.table_location_list.item(row,column).text()
+        x= self.location_list[row,0]
+        y= self.location_list[row,1]
+        self.navigationViewer.deregister_fov_to_image(x,y)
+    
+        val_edit = self.table_location_list.item(row,column).text()
         if column < 2:
-            x = float(x)
-            self.location_list[row,column] = x
+            val_edit = float(val_edit)
+            self.location_list[row,column] = val_edit
         elif column == 2:
-            z = float(x)/1000
+            z = float(val_edit)/1000
             self.location_list[row,column] = z
         else:
-            self.location_ids[row] = x
-
+            self.location_ids[row] = val_edit
+        
+        self.navigationViewer.register_fov_to_image(self.location_list[row,0], self.location_list[row,1])
         location_str = 'x: ' + str(round(self.location_list[row,0],3)) + ' mm, y: ' + str(round(self.location_list[row,1],3)) + ' mm, z: ' + str(1000*round(self.location_list[row,2],3)) + ' um'
         self.dropdown_location_list.setItemText(row, location_str)
         self.go_to(row)


### PR DESCRIPTION
This PR implements an editable points table. Users often need to quickly move across positions, and using the dropdown menu is not practical for that. Also editing values via the GUI is not practical. This PR implements the following features:
- A table with the current positions.
- When clicking positions in the table they get selected.
- When editing the values, those get propagated to other relevant places, such as the drop-down menu.
- The table can be opened using the ```Show Location List``` button.

In addition this PR also implements a point ID for the well-plate setup. Currently points are only characterized by their location, making it very difficult to related them to wells. Now each point receives a name of type ```C12-0``` where ```C12``` is the well name and ```0``` a unique ID in case multiple points are selected in a well. This ID is also visible in the points table. In order to have a access to well names from the ```MultiPointWidget2``` object, that latter can now optionally accept a ```ScanCoordinates```  object.