### PR TITLE
Master napari performance

### DIFF
--- a/software/control/core.py
+++ b/software/control/core.py
@@ -2115,10 +2115,7 @@ class MultiPointWorker(QObject):
                                 height = int(I.shape[0]/PRVIEW_DOWNSAMPLE_FACTOR)
                                 I = cv2.resize(I, (width,height), interpolation=cv2.INTER_AREA)
                                 # populate the tiled_preview
-                                if sgn_j == 1:
-                                    self.tiled_preview[(self.NY-i-1)*height:(self.NY-i)*height, j*width:(j+1)*width, ] = I
-                                else:
-                                    self.tiled_preview[(self.NY-i-1)*height:(self.NY-i)*height, (self.NX-j-1)*width:(self.NX-j)*width, ] = I
+                                self.tiled_preview[(self.NY-real_i-1)*height:(self.NY-real_i)*height, real_j*width:(real_j+1)*width, ] = I
                                 # emit the result
                                 self.image_to_display_tiled_preview.emit(self.tiled_preview)
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2821,7 +2821,7 @@ class NapariMultiChannelWidget(QWidget):
         self.image_width = 0
         self.image_height = 0
         self.dtype = np.uint8
-        self.channels = []
+        self.channels = set()
         self.contrast_limits = {}
         self.pixel_size_um = 1
         self.layers_initialized = False
@@ -2844,7 +2844,7 @@ class NapariMultiChannelWidget(QWidget):
         self.Nz = Nz
 
     def initChannels(self, channels):
-        self.channels = channels
+        self.channels = set(channels)
 
     def extractWavelength(self, name):
         # Split the string and find the wavelength number immediately after "Fluorescence"
@@ -2869,7 +2869,10 @@ class NapariMultiChannelWidget(QWidget):
 
     def initLayers(self, image_height, image_width, image_dtype, rgb=False):
         """Initializes the full canvas for each channel based on the acquisition parameters."""
-        self.viewer.layers.clear()
+        #self.viewer.layers.clear()
+        for layer in list(self.viewer.layers):
+            if layer.name not in self.channels:
+                self.viewer.layers.remove(layer)
         self.image_width = image_width
         self.image_height = image_height
         self.dtype = np.dtype(image_dtype)
@@ -2882,7 +2885,7 @@ class NapariMultiChannelWidget(QWidget):
  
         rgb = len(image.shape) == 3
         if channel_name not in self.viewer.layers:
-            self.channels.append(channel_name)
+            self.channels.add(channel_name)
             if rgb:
                 color = None  # RGB images do not need a colormap
                 canvas = np.zeros((self.Nz, self.image_height, self.image_width, 3), dtype=self.dtype)
@@ -2945,7 +2948,7 @@ class NapariTiledDisplayWidget(QWidget):
         self.image_width = 0
         self.image_height = 0
         self.dtype = np.uint8
-        self.channels = []
+        self.channels = set()
         self.Nx = 1
         self.Ny = 1
         self.Nz = 1
@@ -2971,7 +2974,7 @@ class NapariTiledDisplayWidget(QWidget):
         self.dz_um = dz
 
     def initChannels(self, channels):
-        self.channels = channels
+        self.channels = set(channels)
 
     def extractWavelength(self, name):
         # Split the string and find the wavelength number immediately after "Fluorescence"
@@ -2995,7 +2998,10 @@ class NapariTiledDisplayWidget(QWidget):
 
     def initLayers(self, image_height, image_width, image_dtype):
         """Initializes the full canvas for each channel based on the acquisition parameters."""
-        self.viewer.layers.clear()
+        #self.viewer.layers.clear()
+        for layer in list(self.viewer.layers):
+            if layer.name not in self.channels:
+                self.viewer.layers.remove(layer)
         self.image_width = image_width // self.downsample_factor
         self.image_height = image_height // self.downsample_factor
         self.dtype = np.dtype(image_dtype)
@@ -3011,7 +3017,7 @@ class NapariTiledDisplayWidget(QWidget):
            self.initLayers(image.shape[0], image.shape[1], image.dtype)
  
         if channel_name not in self.viewer.layers:
-            self.channels.append(channel_name)
+            self.channels.add(channel_name)
             if rgb:
                 color = None  # No colormap for RGB images
                 canvas = np.zeros((self.Nz, self.Ny * self.image_height, self.Nx * self.image_width, 3), dtype=self.dtype)


### PR DESCRIPTION
# fix performance delay caused by napari widgets:
no long clears channel layers between acquisitions, wells, and fovs unless necessary 
multichannel widget refreshes all layers at once after the last channel has been scanned and emitted.