### PR TITLE
bug fix window size to int

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -407,7 +407,7 @@ class OctopiGUI(QMainWindow):
             desktopWidget = QDesktopWidget()
             width = 0.96*desktopWidget.height()
             height = width
-            self.tabbedImageDisplayWindow.setFixedSize(width,height)
+            self.tabbedImageDisplayWindow.setFixedSize(int(width), int(height))
             self.tabbedImageDisplayWindow.show()
 
         '''


### PR DESCRIPTION
A missing int casting prevents multi-window usage when ```SINGLE_WINDOW = False```.