### PR TITLE
Objective selection

### DIFF
--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -441,7 +441,6 @@ class OctopiGUI(QMainWindow):
         self.liveControlWidget.signal_newExposureTime.connect(self.cameraSettingWidget.set_exposure_time)
         self.liveControlWidget.signal_newAnalogGain.connect(self.cameraSettingWidget.set_analog_gain)
         self.liveControlWidget.update_camera_settings()
-        self.objectivesWidget.signal_objective_changed.connect(self.navigationViewer.on_objective_changed)
 
         # load vs scan position switching
         self.slidePositionController.signal_slide_loading_position_reached.connect(self.navigationWidget.slot_slide_loading_position_reached)
@@ -451,6 +450,7 @@ class OctopiGUI(QMainWindow):
         self.slidePositionController.signal_clear_slide.connect(self.navigationViewer.clear_slide)
 
         # display the FOV in the viewer
+        self.objectivesWidget.signal_objective_changed.connect(self.navigationViewer.on_objective_changed)
         self.navigationController.xyPos.connect(self.navigationViewer.update_current_location)
         self.multipointController.signal_register_current_fov.connect(self.navigationViewer.register_fov)
         self.multipointController.signal_current_configuration.connect(self.liveControlWidget.set_microscope_mode)

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -298,7 +298,7 @@ class OctopiGUI(QMainWindow):
         self.imageDisplayTabs = QTabWidget()
 
         if USE_NAPARI_FOR_LIVE_VIEW:
-            self.napariLiveWidget = widgets.NapariLiveWidget(self.configurationManager, self.liveControlWidget)
+            self.napariLiveWidget = widgets.NapariLiveWidget(self.liveControlWidget)
             self.imageDisplayTabs.addTab(self.napariLiveWidget, "Live View")
         else:
             if ENABLE_TRACKING:
@@ -309,7 +309,7 @@ class OctopiGUI(QMainWindow):
             self.imageDisplayTabs.addTab(self.imageDisplayWindow.widget, "Live View")
 
         if USE_NAPARI_FOR_MULTIPOINT:
-            self.napariMultiChannelWidget = widgets.NapariMultiChannelWidget(self.configurationManager)
+            self.napariMultiChannelWidget = widgets.NapariMultiChannelWidget(self.objectiveStore)
             # self.napariMultiChannelWidget.set_pixel_size_um(3.76*2/60)  
             # ^ for 60x, IMX571, 2x2 binning, to change to using objective and camera config
             self.imageDisplayTabs.addTab(self.napariMultiChannelWidget, "Multichannel Acquisition")
@@ -319,7 +319,7 @@ class OctopiGUI(QMainWindow):
 
         if SHOW_TILED_PREVIEW:
             if USE_NAPARI_FOR_TILED_DISPLAY:
-                self.napariTiledDisplayWidget = widgets.NapariTiledDisplayWidget(self.configurationManager)
+                self.napariTiledDisplayWidget = widgets.NapariTiledDisplayWidget(self.objectiveStore)
                 self.imageDisplayTabs.addTab(self.napariTiledDisplayWidget, "Tiled Preview")
             else:
                 self.imageDisplayWindow_scan_preview = core.ImageDisplayWindow(draw_crosshairs=True) 

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -144,7 +144,7 @@ class OctopiGUI(QMainWindow):
 
         print('load channel_configurations.xml')
         self.configurationManager = core.ConfigurationManager(filename='./channel_configurations.xml')
-        self.objectiveStore = core.ObjectiveStore() # todo: add widget to select/save objective save
+        self.objectiveStore = core.ObjectiveStore(parent=self) # todo: add widget to select/save objective save
         self.streamHandler = core.StreamHandler(display_resolution_scaling=DEFAULT_DISPLAY_CROP/100)
         self.liveController = core.LiveController(self.camera,self.microcontroller,self.configurationManager,parent=self)
         self.navigationController = core.NavigationController(self.microcontroller, self.objectiveStore, parent=self)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2911,9 +2911,9 @@ class NapariMultiChannelWidget(QWidget):
         layer = self.viewer.layers[channel_name]
         layer.data[k] = image
         layer.contrast_limits = self.contrast_limits.get(layer.name, self.getContrastLimits(self.dtype))
-        self.viewer.dims.set_point(0, k * self.dz_um)
         self.update_layer_count += 1
         if self.update_layer_count % len(self.channels) == 0:
+            self.viewer.dims.set_point(0, k * self.dz_um)
             for layer in self.viewer.layers:
                 layer.refresh()
 

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2912,12 +2912,11 @@ class NapariMultiChannelWidget(QWidget):
         layer = self.viewer.layers[channel_name]
         layer.data[k] = image
         layer.contrast_limits = self.contrast_limits.get(layer.name, self.getContrastLimits(self.dtype))
+        self.viewer.dims.set_point(0, k * self.dz_um)
         self.update_layer_count += 1
-        if self.update_layer_count == len(self.channels):
-            self.viewer.dims.set_point(0, k)
+        if self.update_layer_count % len(self.channels) == 0:
             for layer in self.viewer.layers:
                 layer.refresh()
-            self.update_layer_count = 0
 
     def getContrastLimits(self, dtype):
         if np.issubdtype(dtype, np.integer):
@@ -2981,7 +2980,7 @@ class NapariTiledDisplayWidget(QWidget):
         self.dx_mm = dx
         self.dy_mm = dy
         self.dz_um = dz
-        self.pixel_size_um = self.objectiveStore.get_pixel_size()
+        self.pixel_size_um = self.objectiveStore.get_pixel_size() * self.downsample_factor
         self.acquisition_initialized = False
 
     def initChannels(self, channels):
@@ -3057,18 +3056,17 @@ class NapariTiledDisplayWidget(QWidget):
         if not self.viewer_scale_initialized:
             self.resetView()
             self.viewer_scale_initialized = True
- 
+        self.viewer.dims.set_point(0, k * self.dz_um)
         layer = self.viewer.layers[channel_name]
         layer_data = layer.data
+
         y_slice = slice(i * self.image_height, (i + 1) * self.image_height)
         x_slice = slice(j * self.image_width, (j + 1) * self.image_width)
         if rgb:
             layer_data[k, y_slice, x_slice, :] = image
         else:
             layer_data[k, y_slice, x_slice] = image
-        
         layer.data = layer_data
-        self.viewer.dims.set_point(0, k)
         layer.refresh()
 
     def signalContrastLimits(self, event):

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2666,10 +2666,10 @@ class NapariLiveWidget(QWidget):
     signal_coordinates_clicked = Signal(int, int, int, int)
     signal_layer_contrast_limits = Signal(str, float, float)
 
-    def __init__(self, configurationManager, liveControlWidget, parent=None):
+    def __init__(self, liveControlWidget, parent=None):
         super().__init__(parent)
         # Initialize placeholders for the acquisition parameters
-        self.configurationManager = configurationManager
+        # self.objectiveStore = objectiveStore
         self.liveControlWidget = liveControlWidget
         self.live_layer_name = ""
         self.image_width = 0
@@ -2801,16 +2801,17 @@ class NapariMultiChannelWidget(QWidget):
 
     signal_layer_contrast_limits = Signal(str, float, float)
 
-    def __init__(self, configurationManager, parent=None):
+    def __init__(self, objectiveStore, parent=None):
         super().__init__(parent)
         # Initialize placeholders for the acquisition parameters
-        self.configurationManager = configurationManager
+        self.objectiveStore = objectiveStore
         self.image_width = 0
         self.image_height = 0
         self.dtype = np.uint8
         self.channels = set()
         self.contrast_limits = {}
         self.pixel_size_um = 1
+        self.dz_um = 1
         self.Nz = 1
         self.layers_initialized = False
         self.acquisition_initialized = False
@@ -2831,9 +2832,11 @@ class NapariMultiChannelWidget(QWidget):
         self.setLayout(self.layout)
         
     def initLayersShape(self, Nx, Ny, Nz, dx, dy, dz):
-        if self.Nz != Nz:
+        if self.Nz != Nz or self.dz_um != dz:
             self.acquisition_initialized = False
-        self.Nz = Nz
+            self.Nz = Nz
+            self.dz_um = dz
+        self.pixel_size_um = self.objectiveStore.get_pixel_size()
         
     def initChannels(self, channels):
         self.channels = set(channels)
@@ -2895,8 +2898,10 @@ class NapariMultiChannelWidget(QWidget):
                 canvas = np.zeros((self.Nz, self.image_height, self.image_width), dtype=self.dtype)
             
             limits = self.getContrastLimits(self.dtype)
+            print("napari scale: ", self.dz_um, self.pixel_size_um, self.pixel_size_um)
             layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb,
-                                          colormap=color, contrast_limits=limits, blending='additive')
+                                          colormap=color, contrast_limits=limits, blending='additive',
+                                          scale=(self.dz_um, self.pixel_size_um, self.pixel_size_um))
             layer.contrast_limits = self.contrast_limits.get(channel_name, limits)
             layer.events.contrast_limits.connect(self.signalContrastLimits)
 
@@ -2941,10 +2946,10 @@ class NapariTiledDisplayWidget(QWidget):
     signal_coordinates_clicked = Signal(int, int, int, int, int, int, float, float)
     signal_layer_contrast_limits = Signal(str, float, float)
 
-    def __init__(self, configurationManager, parent=None):
+    def __init__(self, objectiveStore, parent=None):
         super().__init__(parent)
         # Initialize placeholders for the acquisition parameters
-        self.configurationManager = configurationManager
+        self.objectiveStore = objectiveStore
         self.downsample_factor = PRVIEW_DOWNSAMPLE_FACTOR
         self.image_width = 0
         self.image_height = 0
@@ -2953,6 +2958,8 @@ class NapariTiledDisplayWidget(QWidget):
         self.Nx = 1
         self.Ny = 1
         self.Nz = 1
+        self.dz_um = 1
+        self.pixel_size_um = 1
         self.layers_initialized = False
         self.acquisition_initialized = False
         self.viewer_scale_initialized = False
@@ -2974,6 +2981,7 @@ class NapariTiledDisplayWidget(QWidget):
         self.dx_mm = dx
         self.dy_mm = dy
         self.dz_um = dz
+        self.pixel_size_um = self.objectiveStore.get_pixel_size()
         self.acquisition_initialized = False
 
     def initChannels(self, channels):
@@ -3036,7 +3044,10 @@ class NapariTiledDisplayWidget(QWidget):
                 canvas = np.zeros((self.Nz, self.Ny * self.image_height, self.Nx * self.image_width), dtype=self.dtype)
 
             limits = self.getContrastLimits(self.dtype)
-            layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb, colormap=color, contrast_limits=limits, blending='additive')
+            print("scale", self.dz_um, self.pixel_size_um, self.pixel_size_um)
+            layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb, 
+                                          colormap=color, contrast_limits=limits, blending='additive', 
+                                          scale=(self.dz_um, self.pixel_size_um, self.pixel_size_um))
             layer.contrast_limits = self.contrast_limits.get(channel_name, limits)
             layer.events.contrast_limits.connect(self.signalContrastLimits)
             layer.mouse_double_click_callbacks.append(self.onDoubleClick)

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2898,7 +2898,6 @@ class NapariMultiChannelWidget(QWidget):
                 canvas = np.zeros((self.Nz, self.image_height, self.image_width), dtype=self.dtype)
             
             limits = self.getContrastLimits(self.dtype)
-            print("napari scale: ", self.dz_um, self.pixel_size_um, self.pixel_size_um)
             layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb,
                                           colormap=color, contrast_limits=limits, blending='additive',
                                           scale=(self.dz_um, self.pixel_size_um, self.pixel_size_um))
@@ -3043,7 +3042,6 @@ class NapariTiledDisplayWidget(QWidget):
                 canvas = np.zeros((self.Nz, self.Ny * self.image_height, self.Nx * self.image_width), dtype=self.dtype)
 
             limits = self.getContrastLimits(self.dtype)
-            print("scale", self.dz_um, self.pixel_size_um, self.pixel_size_um)
             layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb, 
                                           colormap=color, contrast_limits=limits, blending='additive', 
                                           scale=(self.dz_um, self.pixel_size_um, self.pixel_size_um))

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -2810,7 +2810,8 @@ class NapariMultiChannelWidget(QWidget):
         self.dtype = np.uint8
         self.channels = set()
         self.contrast_limits = {}
-        self.pixel_size_um = 1
+        self.pixel_size_x_um = 1
+        self.pixel_size_y_um = 1
         self.dz_um = 1
         self.Nz = 1
         self.layers_initialized = False
@@ -2836,7 +2837,7 @@ class NapariMultiChannelWidget(QWidget):
             self.acquisition_initialized = False
             self.Nz = Nz
             self.dz_um = dz
-        self.pixel_size_um = self.objectiveStore.get_pixel_size()
+        self.pixel_size_x_um, self.pixel_size_y_um = self.objectiveStore.get_pixel_size()
         
     def initChannels(self, channels):
         self.channels = set(channels)
@@ -2900,7 +2901,8 @@ class NapariMultiChannelWidget(QWidget):
             limits = self.getContrastLimits(self.dtype)
             layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb,
                                           colormap=color, contrast_limits=limits, blending='additive',
-                                          scale=(self.dz_um, self.pixel_size_um, self.pixel_size_um))
+                                          scale=(self.dz_um, self.pixel_size_y_um, self.pixel_size_x_um))
+            print(f"multi channel - dz_um:{self.dz_um}, pixel_y_um:{self.pixel_size_y_um}, pixel_x_um:{self.pixel_size_x_um}")
             layer.contrast_limits = self.contrast_limits.get(channel_name, limits)
             layer.events.contrast_limits.connect(self.signalContrastLimits)
 
@@ -2957,7 +2959,8 @@ class NapariTiledDisplayWidget(QWidget):
         self.Ny = 1
         self.Nz = 1
         self.dz_um = 1
-        self.pixel_size_um = 1
+        self.pixel_size_x_um = 1 # um
+        self.pixel_size_y_um = 1 # um
         self.layers_initialized = False
         self.acquisition_initialized = False
         self.viewer_scale_initialized = False
@@ -2973,14 +2976,16 @@ class NapariTiledDisplayWidget(QWidget):
         self.setLayout(self.layout)
         
     def initLayersShape(self, Nx, Ny, Nz, dx, dy, dz):
+        self.acquisition_initialized = False
         self.Nx = Nx
         self.Ny = Ny
         self.Nz = Nz
         self.dx_mm = dx
         self.dy_mm = dy
         self.dz_um = dz
-        self.pixel_size_um = self.objectiveStore.get_pixel_size() * self.downsample_factor
-        self.acquisition_initialized = False
+        pixel_size_x_um, pixel_size_y_um = self.objectiveStore.get_pixel_size()
+        self.pixel_size_x_um = pixel_size_x_um * self.downsample_factor
+        self.pixel_size_y_um = pixel_size_y_um * self.downsample_factor
 
     def initChannels(self, channels):
         self.channels = set(channels)
@@ -3044,7 +3049,8 @@ class NapariTiledDisplayWidget(QWidget):
             limits = self.getContrastLimits(self.dtype)
             layer = self.viewer.add_image(canvas, name=channel_name, visible=True, rgb=rgb, 
                                           colormap=color, contrast_limits=limits, blending='additive', 
-                                          scale=(self.dz_um, self.pixel_size_um, self.pixel_size_um))
+                                          scale=(self.dz_um, self.pixel_size_y_um, self.pixel_size_x_um))
+            print(f"tiled display - dz_um:{self.dz_um}, pixel_y_um:{self.pixel_size_y_um}, pixel_x_um:{self.pixel_size_x_um}")
             layer.contrast_limits = self.contrast_limits.get(channel_name, limits)
             layer.events.contrast_limits.connect(self.signalContrastLimits)
             layer.mouse_double_click_callbacks.append(self.onDoubleClick)


### PR DESCRIPTION
fixed z-scale rendering on napari widgets. 
- get_pixel_size from objectiveStore
- signal dz_um and Nz for viewer z-data.
z-scale already good for stitched images from stitching branch.