### PR TITLE
setup_octopi.sh: fail on errors, TRACE ability, and updated conda cuda package

### DIFF
--- a/software/setup_octopi.sh
+++ b/software/setup_octopi.sh
@@ -147,7 +147,7 @@ install_conditional_packages() {
     echo "Installing conditional packages..."
     if [ "${os}" == "Linux" ]; then
         pip install cuda-python cupy-cuda12x
-        conda install -y pytorch torchvision torchaudio cudatoolkit=12.1 -c pytorch -c nvidia
+        conda install -y pytorch torchvision torchaudio cuda-version=12.1 -c pytorch -c nvidia
         pip install 'jax[cuda12_pip]==0.4.23' --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
     elif [ "${os}" == "MacOS" ]; then
         pip install torch torchvision torchaudio 

--- a/software/setup_octopi.sh
+++ b/software/setup_octopi.sh
@@ -116,6 +116,11 @@ create_conda_env() {
     local env_name="octopi"
     local python_version="3.10"
 
+    if ! which conda; then
+      echo "No conda found, please install conda then re-run."
+      exit 1
+    fi
+
     if conda info --envs | grep -qw "$env_name"; then
         echo "Conda environment '$env_name' already exists. Activating it..."
     else

--- a/software/setup_octopi.sh
+++ b/software/setup_octopi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Setup script for octopi-software environment
 # -------------------------------------------------------
 # Usage
@@ -15,6 +15,12 @@
 # conda activate octopi
 # python main.py --simulation
 # -------------------------------------------------------
+set -eo pipefail
+
+if [[ -n "$TRACE" ]]; then
+  echo "TRACE variable non-empty, turning on script tracing."
+  set -x
+fi
 
 # Detect Operating System
 OS="$(uname -s)"


### PR DESCRIPTION
This makes the setup script fail on the first command that has an unchecked error, and makes tracing what's happening while debugging easier via the `TRACE` environment variable.

Also, while testing, the `cudatoolkit=12.1` package failed (it looks like only up to 11.8 is on conda-forge and the nvidia channels), so this instead uses the `cuda-version` meta package to grab version 12.1.  This part could be a mixup in my setup - if there's a channel with cudatoolkit=12.1 let me know!

NOTE: For a future pull request, regardless of the answer, it looks like we still install cuda relevant packages even if `$INSTALL_CUDA` is not specified.  Is that intended?

Tested by:
1. Running `./setup_octopi.sh` without conda installed and making sure it fails with a non-zero error code, and prints a message.
2. Running `TRACE=1 ./setup_octopi.sh` and making sure the `+` trace messages are shown
3. Running `./setup_octopi.sh` on an Ubuntu 22.04 system and making sure it runs successfully (after installing conda).