### PR TITLE
sample format related bug fix and cleanup

### DIFF
--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -619,7 +619,7 @@ def read_sample_formats_csv(file_path):
     with open(file_path, 'r') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            format_key = int(row['format'])
+            format_key = str(row['format'])
             sample_formats[format_key] = {
                 'a1_x_mm': float(row['a1_x_mm']),
                 'a1_y_mm': float(row['a1_y_mm']),
@@ -748,10 +748,10 @@ try:
     with open("cache/objective_and_sample_format.txt", 'r') as f:
         cached_settings = json.load(f)
         DEFAULT_OBJECTIVE = cached_settings.get('objective') if cached_settings.get('objective') in OBJECTIVES else '20x'
-        WELLPLATE_FORMAT = cached_settings.get('wellplate_format') if (cached_settings.get('wellplate_format') in WELLPLATE_FORMAT_SETTINGS or cached_settings.get('wellplate_format') == 0) else 384
+        WELLPLATE_FORMAT = str(cached_settings.get('wellplate_format')) if (cached_settings.get('wellplate_format') in WELLPLATE_FORMAT_SETTINGS or cached_settings.get('wellplate_format') == 0) else '96'
 except (FileNotFoundError, json.JSONDecodeError):
     DEFAULT_OBJECTIVE = '20x'
-    WELLPLATE_FORMAT = 384
+    WELLPLATE_FORMAT = '96'
 
 NUMBER_OF_SKIP = WELLPLATE_FORMAT_SETTINGS[WELLPLATE_FORMAT]['number_of_skip'] # num rows/cols to skip on wellplate edge
 WELL_SIZE_MM = WELLPLATE_FORMAT_SETTINGS[WELLPLATE_FORMAT]['well_size_mm']

--- a/software/control/_def.py
+++ b/software/control/_def.py
@@ -619,7 +619,8 @@ def read_sample_formats_csv(file_path):
     with open(file_path, 'r') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            format_key = str(row['format'])
+            format_ = str(row['format'])
+            format_key = f"{format_} well plate" if format_.isdigit() else format_
             sample_formats[format_key] = {
                 'a1_x_mm': float(row['a1_x_mm']),
                 'a1_y_mm': float(row['a1_y_mm']),
@@ -748,10 +749,13 @@ try:
     with open("cache/objective_and_sample_format.txt", 'r') as f:
         cached_settings = json.load(f)
         DEFAULT_OBJECTIVE = cached_settings.get('objective') if cached_settings.get('objective') in OBJECTIVES else '20x'
-        WELLPLATE_FORMAT = str(cached_settings.get('wellplate_format')) if (cached_settings.get('wellplate_format') in WELLPLATE_FORMAT_SETTINGS or cached_settings.get('wellplate_format') == 0) else '96'
+        WELLPLATE_FORMAT = str(cached_settings.get('wellplate_format'))
+        WELLPLATE_FORMAT = WELLPLATE_FORMAT + ' well plate' if WELLPLATE_FORMAT.isdigit() else WELLPLATE_FORMAT
+        if WELLPLATE_FORMAT not in WELLPLATE_FORMAT_SETTINGS:
+            WELLPLATE_FORMAT = '96 well plate'
 except (FileNotFoundError, json.JSONDecodeError):
     DEFAULT_OBJECTIVE = '20x'
-    WELLPLATE_FORMAT = '96'
+    WELLPLATE_FORMAT = '96 well plate'
 
 NUMBER_OF_SKIP = WELLPLATE_FORMAT_SETTINGS[WELLPLATE_FORMAT]['number_of_skip'] # num rows/cols to skip on wellplate edge
 WELL_SIZE_MM = WELLPLATE_FORMAT_SETTINGS[WELLPLATE_FORMAT]['well_size_mm']

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -3696,14 +3696,14 @@ class NavigationViewer(QFrame):
         if isinstance(sample_format, QVariant):
             sample_format = sample_format.value()
 
-        if sample_format == 0:
+        if sample_format == '0':
             if IS_HCS:
                 sample = '4 glass slide'
             else:
                 sample = 'glass slide'
-        elif isinstance(sample_format, int):
+        elif sample_format.isdigit():
             sample = f'{sample_format} well plate'
-        else:  # Custom wellplate
+        else:
             sample = sample_format
 
         self.sample = sample
@@ -3721,7 +3721,8 @@ class NavigationViewer(QFrame):
         image_path = self.image_paths.get(sample)
         if image_path is None or not os.path.exists(image_path):
             # Look for a custom wellplate image
-            custom_image_path = os.path.join('images', f'{sample.replace(" ", "_")}.png')
+            custom_image_path = os.path.join('images', self.sample, '.png')
+            print(custom_image_path)
             if os.path.exists(custom_image_path):
                 image_path = custom_image_path
             else:

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -3701,8 +3701,6 @@ class NavigationViewer(QFrame):
                 sample = '4 glass slide'
             else:
                 sample = 'glass slide'
-        elif sample_format.isdigit():
-            sample = f'{sample_format} well plate'
         else:
             sample = sample_format
 

--- a/software/control/core.py
+++ b/software/control/core.py
@@ -3721,7 +3721,7 @@ class NavigationViewer(QFrame):
         image_path = self.image_paths.get(sample)
         if image_path is None or not os.path.exists(image_path):
             # Look for a custom wellplate image
-            custom_image_path = os.path.join('images', self.sample, '.png')
+            custom_image_path = os.path.join('images', self.sample + '.png')
             print(custom_image_path)
             if os.path.exists(custom_image_path):
                 image_path = custom_image_path

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -155,7 +155,7 @@ class OctopiGUI(QMainWindow):
         if WELLPLATE_FORMAT == 0:
             self.navigationViewer = core.NavigationViewer(self.objectiveStore, sample='4 glass slide')
         else:
-            self.navigationViewer = core.NavigationViewer(self.objectiveStore, sample=f'{WELLPLATE_FORMAT} well plate')
+            self.navigationViewer = core.NavigationViewer(self.objectiveStore, sample=WELLPLATE_FORMAT)
 
         if SUPPORT_LASER_AUTOFOCUS:
             self.configurationManager_focus_camera = core.ConfigurationManager(filename='./focus_camera_configurations.xml')
@@ -366,7 +366,7 @@ class OctopiGUI(QMainWindow):
 
         self.recordingControlWidget = widgets.RecordingWidget(self.streamHandler, self.imageSaver)
         self.wellplateFormatWidget = widgets.WellplateFormatWidget(self.navigationController, self.navigationViewer, self.streamHandler, self.liveController)
-        if WELLPLATE_FORMAT != '1536':
+        if WELLPLATE_FORMAT != '1536 well plate':
             self.wellSelectionWidget = widgets.WellSelectionWidget(WELLPLATE_FORMAT, self.wellplateFormatWidget)
         else:
             self.wellSelectionWidget = widgets.Well1536SelectionWidget()
@@ -907,7 +907,7 @@ class OctopiGUI(QMainWindow):
             self.navigationController.inverted_objective = True
             self.setupSlidePositionController(is_for_wellplate=True)
 
-            if format_ == '1536':
+            if format_ == '1536 well plate':
                 self.replaceWellSelectionWidget(widgets.Well1536SelectionWidget())
             elif isinstance(self.wellSelectionWidget, widgets.Well1536SelectionWidget):
                 self.replaceWellSelectionWidget(widgets.WellSelectionWidget(format_, self.wellplateFormatWidget))

--- a/software/control/gui_hcs.py
+++ b/software/control/gui_hcs.py
@@ -366,7 +366,7 @@ class OctopiGUI(QMainWindow):
 
         self.recordingControlWidget = widgets.RecordingWidget(self.streamHandler, self.imageSaver)
         self.wellplateFormatWidget = widgets.WellplateFormatWidget(self.navigationController, self.navigationViewer, self.streamHandler, self.liveController)
-        if WELLPLATE_FORMAT != 1536:
+        if WELLPLATE_FORMAT != '1536':
             self.wellSelectionWidget = widgets.WellSelectionWidget(WELLPLATE_FORMAT, self.wellplateFormatWidget)
         else:
             self.wellSelectionWidget = widgets.Well1536SelectionWidget()
@@ -907,7 +907,7 @@ class OctopiGUI(QMainWindow):
             self.navigationController.inverted_objective = True
             self.setupSlidePositionController(is_for_wellplate=True)
 
-            if format_ == 1536:
+            if format_ == '1536':
                 self.replaceWellSelectionWidget(widgets.Well1536SelectionWidget())
             elif isinstance(self.wellSelectionWidget, widgets.Well1536SelectionWidget):
                 self.replaceWellSelectionWidget(widgets.WellSelectionWidget(format_, self.wellplateFormatWidget))

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3622,7 +3622,7 @@ class MultiPointWidgetGrid(QFrame):
             self.update_scan_size_from_coverage()
 
     def set_default_shape(self):
-        if self.scanCoordinates.format in [384, 1536]:
+        if self.scanCoordinates.format in ['384', '1536']:
             self.combobox_shape.setCurrentText('Square')
         elif self.scanCoordinates.format != 0:
             self.combobox_shape.setCurrentText('Circle')
@@ -6524,7 +6524,6 @@ class WellplateFormatWidget(QWidget):
         self.streamHandler = streamHandler
         self.liveController = liveController
         self.wellplate_format = WELLPLATE_FORMAT
-        self.custom_formats = {}
         self.csv_path = SAMPLE_FORMATS_CSV_PATH # 'sample_formats.csv'
         self.load_formats_from_csv()
         self.initUI()
@@ -6544,11 +6543,9 @@ class WellplateFormatWidget(QWidget):
 
     def populate_combo_box(self):
         self.comboBox.clear()
-        self.comboBox.addItem("glass slide", 0)
+        self.comboBox.addItem("glass slide", '0')
         for format_, settings in WELLPLATE_FORMAT_SETTINGS.items():
-            self.comboBox.addItem(f"{format_} well plate", int(format_))
-        for name in self.custom_formats:
-            self.comboBox.addItem(name, name)
+            self.comboBox.addItem(f"{format_} well plate" if format_.isdigit() else format_, format_)
 
         # Add custom item and set its font to italic
         self.comboBox.addItem("calibrate format...", 'custom')
@@ -6572,9 +6569,7 @@ class WellplateFormatWidget(QWidget):
     def setWellplateSettings(self, wellplate_format):
         if wellplate_format in WELLPLATE_FORMAT_SETTINGS:
             settings = WELLPLATE_FORMAT_SETTINGS[wellplate_format]
-        elif isinstance(wellplate_format, str) and wellplate_format in self.custom_formats:
-            settings = self.custom_formats[wellplate_format]
-        elif wellplate_format == 0:
+        elif wellplate_format == '0':
             self.signalWellplateSettings.emit(QVariant(0), 0, 0, 0, 0, 0, 0, 0, 1, 1)
             return
         else:
@@ -6597,11 +6592,9 @@ class WellplateFormatWidget(QWidget):
     def getWellplateSettings(self, wellplate_format):
         if wellplate_format in WELLPLATE_FORMAT_SETTINGS:
             settings = WELLPLATE_FORMAT_SETTINGS[wellplate_format]
-        elif isinstance(wellplate_format, str) and wellplate_format in self.custom_formats:
-            settings = self.custom_formats[wellplate_format]
-        elif wellplate_format == 0:
+        elif wellplate_format == '0':
             settings = {
-                'format': 0,
+                'format': '0',
                 'a1_x_mm': 0,
                 'a1_y_mm': 0,
                 'a1_x_pixel': 0,
@@ -6617,7 +6610,7 @@ class WellplateFormatWidget(QWidget):
         return settings
 
     def add_custom_format(self, name, settings):
-        self.custom_formats[name] = settings
+        self.WELLPLATE_FORMAT_SETTINGS[name] = settings
         self.populate_combo_box()
         index = self.comboBox.findData(name)
         if index >= 0:
@@ -6641,12 +6634,9 @@ class WellplateFormatWidget(QWidget):
                 reader = csv.DictReader(csvfile)
                 for row in reader:
                     format_ = row['format']
-                    if format_.isdigit():
-                        format_ = int(format_)
-                        if format_ not in WELLPLATE_FORMAT_SETTINGS:
-                            WELLPLATE_FORMAT_SETTINGS[format_] = self.parse_csv_row(row)
-                    else:
-                        self.custom_formats[format_] = self.parse_csv_row(row)
+                    if format_ not in WELLPLATE_FORMAT_SETTINGS:
+                        WELLPLATE_FORMAT_SETTINGS[format_] = self.parse_csv_row(row)
+
         except FileNotFoundError:
             print(f"CSV file not found: {cache_path}")
 
@@ -6660,8 +6650,6 @@ class WellplateFormatWidget(QWidget):
             writer.writeheader()
             for format_, settings in WELLPLATE_FORMAT_SETTINGS.items():
                 writer.writerow({**{'format': format_}, **settings})
-            for name, settings in self.custom_formats.items():
-                writer.writerow({**{'format': name}, **settings})
 
     @staticmethod
     def parse_csv_row(row):
@@ -6911,8 +6899,6 @@ class WellplateCalibration(QDialog):
         self.existing_format_combo.clear()
         for format_ in WELLPLATE_FORMAT_SETTINGS:
             self.existing_format_combo.addItem(f"{format_} well plate", format_)
-        for name in self.wellplateFormatWidget.custom_formats:
-            self.existing_format_combo.addItem(name, name)
 
     def toggle_input_mode(self):
         if self.new_format_radio.isChecked():
@@ -6976,10 +6962,7 @@ class WellplateCalibration(QDialog):
                 a1_x_mm, a1_y_mm = center
 
                 # Get the existing format settings
-                if isinstance(selected_format, int):
-                    existing_settings = WELLPLATE_FORMAT_SETTINGS[selected_format]
-                else:
-                    existing_settings = self.wellplateFormatWidget.custom_formats[selected_format]
+                existing_settings = WELLPLATE_FORMAT_SETTINGS[selected_format]
 
                 # # Calculate the offset between the original 0,0 pixel and 0,0 mm
                 # original_offset_x = existing_settings['a1_x_mm'] - (existing_settings['a1_x_pixel'] * 0.084665)
@@ -7000,10 +6983,7 @@ class WellplateCalibration(QDialog):
                     'well_size_mm': well_size_mm,
                 }
 
-                if isinstance(selected_format, int):
-                    WELLPLATE_FORMAT_SETTINGS[selected_format].update(updated_settings)
-                else:
-                    self.wellplateFormatWidget.custom_formats[selected_format].update(updated_settings)
+                WELLPLATE_FORMAT_SETTINGS[selected_format].update(updated_settings)
 
                 self.wellplateFormatWidget.save_formats_to_csv()
                 self.wellplateFormatWidget.setWellplateSettings(selected_format)
@@ -7407,7 +7387,7 @@ class WellSelectionWidget(QTableWidget):
         self.setDragDropOverwriteMode(False)
         self.setMouseTracking(False)
 
-        if self.format == 1536:
+        if self.format == '1536':
             font = QFont()
             font.setPointSize(6)  # You can adjust this value as needed
         else:
@@ -7565,7 +7545,7 @@ class Well1536SelectionWidget(QWidget):
 
     def __init__(self):
         super().__init__()
-        self.format = 1536
+        self.format = '1536'
         self.selected_cells = {}  # Dictionary to keep track of selected cells and their colors
         self.current_cell = None  # To track the current (green) cell
         self.rows = 32

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -3622,7 +3622,7 @@ class MultiPointWidgetGrid(QFrame):
             self.update_scan_size_from_coverage()
 
     def set_default_shape(self):
-        if self.scanCoordinates.format in ['384', '1536']:
+        if self.scanCoordinates.format in ['384 well plate', '1536 well plate']:
             self.combobox_shape.setCurrentText('Square')
         elif self.scanCoordinates.format != 0:
             self.combobox_shape.setCurrentText('Circle')
@@ -6545,7 +6545,7 @@ class WellplateFormatWidget(QWidget):
         self.comboBox.clear()
         self.comboBox.addItem("glass slide", '0')
         for format_, settings in WELLPLATE_FORMAT_SETTINGS.items():
-            self.comboBox.addItem(f"{format_} well plate" if format_.isdigit() else format_, format_)
+            self.comboBox.addItem(format_, format_)
 
         # Add custom item and set its font to italic
         self.comboBox.addItem("calibrate format...", 'custom')
@@ -6634,6 +6634,7 @@ class WellplateFormatWidget(QWidget):
                 reader = csv.DictReader(csvfile)
                 for row in reader:
                     format_ = row['format']
+                    format_ = format_ + ' well plate' if format_.isdigit() else format_
                     if format_ not in WELLPLATE_FORMAT_SETTINGS:
                         WELLPLATE_FORMAT_SETTINGS[format_] = self.parse_csv_row(row)
 
@@ -7387,7 +7388,7 @@ class WellSelectionWidget(QTableWidget):
         self.setDragDropOverwriteMode(False)
         self.setMouseTracking(False)
 
-        if self.format == '1536':
+        if self.format == '1536 well plate':
             font = QFont()
             font.setPointSize(6)  # You can adjust this value as needed
         else:
@@ -7545,7 +7546,7 @@ class Well1536SelectionWidget(QWidget):
 
     def __init__(self):
         super().__init__()
-        self.format = '1536'
+        self.format = '1536 well plate'
         self.selected_cells = {}  # Dictionary to keep track of selected cells and their colors
         self.current_cell = None  # To track the current (green) cell
         self.rows = 32

--- a/software/control/widgets.py
+++ b/software/control/widgets.py
@@ -6525,7 +6525,6 @@ class WellplateFormatWidget(QWidget):
         self.liveController = liveController
         self.wellplate_format = WELLPLATE_FORMAT
         self.csv_path = SAMPLE_FORMATS_CSV_PATH # 'sample_formats.csv'
-        self.load_formats_from_csv()
         self.initUI()
 
     def initUI(self):
@@ -6616,30 +6615,6 @@ class WellplateFormatWidget(QWidget):
         if index >= 0:
             self.comboBox.setCurrentIndex(index)
         self.wellplateChanged(index)
-
-    def load_formats_from_csv(self):
-        cache_path = os.path.join('cache', self.csv_path)
-        config_path = os.path.join('objective_and_sample_formats', self.csv_path)
-
-        if os.path.exists(cache_path):
-            pass
-        elif os.path.exists(config_path):
-            os.makedirs('cache', exist_ok=True)
-            shutil.copy(config_path, cache_path)
-        else:
-            print(f"CSV file not found in cache or configurations: {config_path}")
-            return
-        try:
-            with open(cache_path, 'r') as csvfile:
-                reader = csv.DictReader(csvfile)
-                for row in reader:
-                    format_ = row['format']
-                    format_ = format_ + ' well plate' if format_.isdigit() else format_
-                    if format_ not in WELLPLATE_FORMAT_SETTINGS:
-                        WELLPLATE_FORMAT_SETTINGS[format_] = self.parse_csv_row(row)
-
-        except FileNotFoundError:
-            print(f"CSV file not found: {cache_path}")
 
     def save_formats_to_csv(self):
         cache_path = os.path.join('cache', self.csv_path)


### PR DESCRIPTION
- change sample format from mixed int and str to str only
- remove custom format as a separate category
- while sample format in the csv can be `96` (for example) for backward compatibility, sample format in the software will be `"96 well plate"` only (not `"96"` or `96`)

To do
- sample format calibration should not be stored in "cache" but in "objective_and_sample_formats"
- `objective_and_sample_formats/sample_formats.csv` should be `objective_and_sample_formats/sample_formats_template.csv` (same for objectives). `sample_formats.csv` should be created by copying `sample_formats_template.csv` and not tracked by git
- cloud backup of users' `sample_formats.csv`?